### PR TITLE
Added a fetch duration timeout to the BaseHttpFetcher. 

### DIFF
--- a/src/main/java/crawlercommons/fetcher/AbortedFetchReason.java
+++ b/src/main/java/crawlercommons/fetcher/AbortedFetchReason.java
@@ -27,4 +27,5 @@ public enum AbortedFetchReason {
     INTERRUPTED, // Fetch was interrupted (typically by FetchBuffer calling
                  // executor.terminate())
     CONTENT_SIZE, // Content exceeds Fetcher.getMaxContentSize()
+    FETCH_DURATION_EXCEEDED, // Fetch has exceeded the duration of time it was allotted 
 }

--- a/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
@@ -33,6 +33,7 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
     public static final int NO_MIN_RESPONSE_RATE = Integer.MIN_VALUE;
     public static final int NO_REDIRECTS = 0;
 
+    public static final int DEFAULT_FETCH_DURATION_TIMEOUT_IN_SECONDS = 100;
     public static final int DEFAULT_MIN_RESPONSE_RATE = NO_MIN_RESPONSE_RATE;
     public static final int DEFAULT_MAX_CONNECTIONS_PER_HOST = 2;
     public static final int DEFAULT_MAX_REDIRECTS = 20;
@@ -41,6 +42,7 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
 
     protected int _maxThreads;
     protected UserAgent _userAgent;
+    protected int _fetchDurationTimeoutInSeconds = DEFAULT_FETCH_DURATION_TIMEOUT_IN_SECONDS;
     protected int _maxRedirects = DEFAULT_MAX_REDIRECTS;
     protected int _maxConnectionsPerHost = DEFAULT_MAX_CONNECTIONS_PER_HOST;
     protected int _minResponseRate = DEFAULT_MIN_RESPONSE_RATE;
@@ -60,6 +62,14 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
 
     public UserAgent getUserAgent() {
         return _userAgent;
+    }
+
+    public void setFetchDurationTimeoutInSeconds(int fetchDurationTimeoutInSeconds) {
+        _fetchDurationTimeoutInSeconds = fetchDurationTimeoutInSeconds;
+    }
+
+    public int getFetchDurationTimeoutInSeconds() {
+        return _fetchDurationTimeoutInSeconds;
     }
 
     public void setMaxConnectionsPerHost(int maxConnectionsPerHost) {

--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -736,6 +736,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
 
                 int readRequests = 0;
                 int minResponseRate = getMinResponseRate();
+                long fetchDurationTimeout = getFetchDurationTimeoutInSeconds() * 1000L;
                 // TODO KKr - we need to monitor the rate while reading a
                 // single block. Look at HttpClient
                 // metrics support for how to do this. Once we fix this, fix
@@ -749,6 +750,9 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                     // Assume read time is at least one millisecond, to avoid
                     // DBZ exception.
                     long totalReadTime = Math.max(1, System.currentTimeMillis() - readStartTime);
+                    if (totalReadTime > fetchDurationTimeout) {
+                        throw new AbortedFetchException(url, "Fetch duration of " + getFetchDurationTimeoutInSeconds() + " sec exceeded", AbortedFetchReason.FETCH_DURATION_EXCEEDED);
+                    }
                     readRate = (totalRead * 1000L) / totalReadTime;
 
                     // Don't bail on the first read cycle, as we can get a

--- a/src/main/java/crawlercommons/util/Headers.java
+++ b/src/main/java/crawlercommons/util/Headers.java
@@ -39,7 +39,7 @@ public class Headers implements Serializable {
     public static final String LAST_MODIFIED = "Last-Modified";
     public static final String LOCATION = "Location";
 
-    private final List<String> EMPTY_VALUES = Collections.unmodifiableList(new ArrayList<String>());
+    private final static List<String> EMPTY_VALUES = Collections.unmodifiableList(new ArrayList<String>());
 
     /**
      * A map of all headers.

--- a/src/test/java/crawlercommons/fetcher/http/SimpleHttpFetcherTest.java
+++ b/src/test/java/crawlercommons/fetcher/http/SimpleHttpFetcherTest.java
@@ -209,6 +209,22 @@ public class SimpleHttpFetcherTest {
     }
 
     @Test
+    public final void testFetchDurationTimeout() throws Exception {
+        // Set up a response handler that provides a response for 2 seconds.
+        startServer(new RandomResponseHandler(20000, 2 * 1000L), 8089);
+        BaseHttpFetcher baseHttpFetcher = new SimpleHttpFetcher(1, TestUtils.CC_TEST_AGENT);
+        baseHttpFetcher.setFetchDurationTimeoutInSeconds(1);  // Limit the fetch duration to 1 second.
+        
+        String url = "http://localhost:8089/test.html";
+        try {
+            baseHttpFetcher.get(url);
+            fail("Exception not thrown");
+        } catch (AbortedFetchException e) {
+            assertTrue(e.getAbortReason() == AbortedFetchReason.FETCH_DURATION_EXCEEDED);
+        }
+    }
+    
+    @Test
     public final void testSlowServerTermination() throws Exception {
         // Need to read in more than 2 8K blocks currently, due to how
         // HttpClientFetcher


### PR DESCRIPTION
If the fetch exceeds this duration, an AbortedFetchException is thrown with a new AbortedFetchReason - FETCH_DURATION_EXCEEDED.

Added a unit test to verify that exception is thrown if the fetch duration exceeds the set limit.
Fixed up the Headers class to make it a “valid” POJO by declaring EMPTY_VALUES as static. (#16)