### PR TITLE
Allow configuration a custom CookieStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
 *.iml
+.idea/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,3 +6,4 @@ Current Development 0.1-SNAPSHOT
 - Remove Tika dependency (aecio via kkrugler) #2
 - Jetty server used for tests is outdated  (aecio via kkrugler) #5
 - Port HttpClient code from crawler-commons (kkrugler) #1
+- Allow configuration of HTTP proxies (aecio via kkrugler) #8

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 http-fetcher Change Log
 
 Current Development 0.1-SNAPSHOT
-- Switch back to Java 1.7 copmpatibility (kkrugler) #13
+- Switch back to Java 1.7 compatibility (kkrugler) #13
 - Don't throw exceptions for HTTP errors (aecio via kkrugler) #7
 - Remove Tika dependency (aecio via kkrugler) #2
 - Jetty server used for tests is outdated  (aecio via kkrugler) #5

--- a/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
@@ -15,6 +15,8 @@
  */
 package crawlercommons.fetcher.http;
 
+import org.apache.http.HttpHost;
+
 import crawlercommons.fetcher.BaseFetcher;
 
 /**
@@ -48,6 +50,7 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
     protected int _minResponseRate = DEFAULT_MIN_RESPONSE_RATE;
     protected String _acceptLanguage = DEFAULT_ACCEPT_LANGUAGE;
     protected RedirectMode _redirectMode = DEFAULT_REDIRECT_MODE;
+    protected HttpHost proxy;
 
     public BaseHttpFetcher(int maxThreads, UserAgent userAgent) {
         super();
@@ -117,6 +120,10 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
 
     public RedirectMode getRedirectMode() {
         return _redirectMode;
+    }
+
+    public void setProxy(String scheme, String host, int port) {
+        this.proxy = new HttpHost(host, port, scheme);
     }
 
 }

--- a/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
@@ -123,7 +123,11 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
     }
 
     public void setProxy(String scheme, String host, int port) {
-        this._proxy = new HttpHost(host, port, scheme);
+        _proxy = new HttpHost(host, port, scheme);
+    }
+
+    public HttpHost getProxy() {
+        return _proxy;
     }
 
 }

--- a/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/BaseHttpFetcher.java
@@ -50,7 +50,7 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
     protected int _minResponseRate = DEFAULT_MIN_RESPONSE_RATE;
     protected String _acceptLanguage = DEFAULT_ACCEPT_LANGUAGE;
     protected RedirectMode _redirectMode = DEFAULT_REDIRECT_MODE;
-    protected HttpHost proxy;
+    protected HttpHost _proxy = null;
 
     public BaseHttpFetcher(int maxThreads, UserAgent userAgent) {
         super();
@@ -123,7 +123,7 @@ public abstract class BaseHttpFetcher extends BaseFetcher {
     }
 
     public void setProxy(String scheme, String host, int port) {
-        this.proxy = new HttpHost(host, port, scheme);
+        this._proxy = new HttpHost(host, port, scheme);
     }
 
 }

--- a/src/main/java/crawlercommons/fetcher/http/CookieStoreProvider.java
+++ b/src/main/java/crawlercommons/fetcher/http/CookieStoreProvider.java
@@ -1,0 +1,7 @@
+package crawlercommons.fetcher.http;
+
+import org.apache.http.client.CookieStore;
+
+public interface CookieStoreProvider {
+    CookieStore get();
+}

--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -116,7 +116,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
     // get Connection from Pool.
     // From initial comment of the deprecated 'CONNECTION_POOL_TIMEOUT' static
     // element:
-    // "This normally doesen't ever hit this timeout, since we manage the number
+    // "This normally doesn't ever hit this timeout, since we manage the number
     // of
     // fetcher threads to be <= the maxThreads value used to configure a
     // HttpFetcher. However the limit of connections/host can cause a timeout,
@@ -149,12 +149,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
 
     private IdleConnectionMonitorThread monitor;
 
-    private ThreadLocal<CookieStore> localCookieStore = new ThreadLocal<CookieStore>() {
-        protected CookieStore initialValue() {
-            CookieStore cookieStore = new LocalCookieStore();
-            return cookieStore;
-        }
-    };
+    private CookieStoreProvider cookieStoreProvider = new ThreadLocalCookieStoreProvider();
 
     private static final String SSL_CONTEXT_NAMES[] = { "TLS", "Default", "SSL", };
 
@@ -496,6 +491,14 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
         _maxRetryCount = maxRetryCount;
     }
 
+    public void setCookieStoreProvider(CookieStoreProvider cookieStoreProvider) {
+        this.cookieStoreProvider = cookieStoreProvider;
+    }
+
+    public CookieStoreProvider getCookieStoreProvider() {
+        return cookieStoreProvider;
+    }
+
     @Override
     public FetchedResult get(String url, Payload payload) throws BaseFetchException {
         try {
@@ -566,7 +569,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
         // Without this we get killed w/lots of threads, due to sync() on single
         // cookie store.
         HttpContext localContext = new BasicHttpContext();
-        CookieStore cookieStore = localCookieStore.get();
+        CookieStore cookieStore = cookieStoreProvider.get();
         localContext.setAttribute(HttpClientContext.COOKIE_STORE, cookieStore);
 
         StringBuilder fetchTrace = null;
@@ -955,7 +958,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                 // cookieParams.setSingleHeader(false);
 
                 // Create and initialize connection socket factory registry
-                RegistryBuilder<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory> create();
+                RegistryBuilder<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create();
                 registry.register("http", PlainConnectionSocketFactory.getSocketFactory());
                 SSLConnectionSocketFactory sf = createSSLConnectionSocketFactory();
                 if (sf != null) {

--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -166,8 +166,6 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
     private int _connectionRequestTimeout;
     private int _maxRetryCount;
 
-    
-
     transient private CloseableHttpClient _httpClient;
     transient private PoolingHttpClientConnectionManager _connectionManager;
 
@@ -250,7 +248,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
             // port number to
             // -1 in that case.
             //
-            // Detailed scenrio:
+            // Detailed scenario:
             // http://www.test.com/MyPage ->
             // http://www.test.com:80/MyRedirectedPage ->
             // http://www.test.com/MyRedirectedPage
@@ -890,7 +888,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                 requestConfigBuilder.setConnectionRequestTimeout(_connectionRequestTimeout);
 
                 if (_proxy != null){
-                    LOGGER.info("Configuring fetcher to use _proxy: "+ _proxy.toURI());
+                    LOGGER.info("Configuring fetcher to use _proxy: " + _proxy.toURI());
                     httpClientBuilder.setProxy(_proxy);
                 }
 

--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -889,9 +889,9 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                 requestConfigBuilder.setConnectTimeout(_connectionTimeout);
                 requestConfigBuilder.setConnectionRequestTimeout(_connectionRequestTimeout);
 
-                if(proxy != null){
-                    LOGGER.info("Configuring fetcher to use proxy: "+proxy.toURI());
-                    httpClientBuilder.setProxy(proxy);
+                if(_proxy != null){
+                    LOGGER.info("Configuring fetcher to use _proxy: "+ _proxy.toURI());
+                    httpClientBuilder.setProxy(_proxy);
                 }
 
                 /*

--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -166,6 +166,8 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
     private int _connectionRequestTimeout;
     private int _maxRetryCount;
 
+    
+
     transient private CloseableHttpClient _httpClient;
     transient private PoolingHttpClientConnectionManager _connectionManager;
 
@@ -886,6 +888,11 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                 requestConfigBuilder.setSocketTimeout(_socketTimeout);
                 requestConfigBuilder.setConnectTimeout(_connectionTimeout);
                 requestConfigBuilder.setConnectionRequestTimeout(_connectionRequestTimeout);
+
+                if(proxy != null){
+                    LOGGER.info("Configuring fetcher to use proxy: "+proxy.toURI());
+                    httpClientBuilder.setProxy(proxy);
+                }
 
                 /*
                  * CoreConnectionPNames.TCP_NODELAY='http.tcp.nodelay':

--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -889,7 +889,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                 requestConfigBuilder.setConnectTimeout(_connectionTimeout);
                 requestConfigBuilder.setConnectionRequestTimeout(_connectionRequestTimeout);
 
-                if(_proxy != null){
+                if (_proxy != null){
                     LOGGER.info("Configuring fetcher to use _proxy: "+ _proxy.toURI());
                     httpClientBuilder.setProxy(_proxy);
                 }

--- a/src/main/java/crawlercommons/fetcher/http/ThreadLocalCookieStoreProvider.java
+++ b/src/main/java/crawlercommons/fetcher/http/ThreadLocalCookieStoreProvider.java
@@ -1,0 +1,12 @@
+package crawlercommons.fetcher.http;
+
+import org.apache.http.client.CookieStore;
+
+class ThreadLocalCookieStoreProvider extends ThreadLocal<CookieStore> implements CookieStoreProvider {
+
+    @Override
+    protected CookieStore initialValue() {
+        return new LocalCookieStore();
+    }
+
+}


### PR DESCRIPTION
Allows users to configure a `CookieStoreProvider` that provides a custom `CookieStore` instance to be used in each request.

Builds on #9, which needs to be merged first.