### PR TITLE
Upgrade project to use Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17 ]
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: crawler-commons-http-fetcher build
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,3 +26,4 @@ Current Development 0.1-SNAPSHOT
 - Bump maven-release-plugin from 2.5.1 to 2.5.3
 - Bump slf4j-api from 1.7.7 to 1.7.36
 - Bump slf4j-log4j12 from 1.7.32 to 1.7.33
+- Upgrade project to use Java 11 (aecio)

--- a/pom.xml
+++ b/pom.xml
@@ -362,9 +362,9 @@
 
 		<!-- General Properties -->
 		<implementation.build>${scmBranch}@r${buildNumber}</implementation.build>
-		<javac.src.version>1.8</javac.src.version>
-		<javac.target.version>1.8</javac.target.version>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<javac.src.version>1.11</javac.src.version>
+		<javac.target.version>1.11</javac.target.version>
+		<maven.compiler.release>11</maven.compiler.release>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
 		<skipTests>false</skipTests>
 		<assembly.finalName>${project.build.finalName}</assembly.finalName>

--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -259,7 +259,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
             // Keep track of the number of redirects.
             Integer count = (Integer) context.getAttribute(REDIRECT_COUNT_CONTEXT_KEY);
             if (count == null) {
-                count = new Integer(0);
+                count = 0;
             }
 
             context.setAttribute(REDIRECT_COUNT_CONTEXT_KEY, count + 1);


### PR DESCRIPTION
Following changes in the `crawler-commons/crawler-commons` project, this PR migrates `crawler-commons/http-fetcher` to Java 11.