### PR TITLE
Allow full configuration of the User-Agent using a builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: crawler-commons-http-fetcher build
 on:
   push:
     branches:
-      - master
+      - "**"
   pull_request:
     branches:
       - master

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,3 +29,4 @@ Current Development 0.1-SNAPSHOT
 - Upgrade project to use Java 11 (aecio)
 - Upgrade tests to use to Jetty 11 (aecio)
 - Upgrade tests to jUnit 5 (aecio)
+- Allow full configuration of the User-Agent using a builder (aecio)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ An example of creating a fetcher with five threads that will only accept content
 
 ``` java
 // Data passed to UserAgent will be used to automatically create HTTP header 'User-Agent'
-UserAgent userAgent = new UserAgent("mycrawler", "crawler@domain.com", "http://domain.com");
+UserAgent ua = new UserAgent.Builder()
+    .setAgentName("MyCrawler")
+    .setCrawlerVersion("1.0")
+    .setWebAddress("www.mycrawler.com/bot.html")
+    .build();
 
 // Instantiate the BaseFetcher object used to fetch pages
-BaseFetcher fetcher = new SimpleHttpFetcher(1, userAgent);
+BaseFetcher fetcher = new SimpleHttpFetcher(5, userAgent);
 
 // Configure the accepted mime-types
 Set<String> validMimeTypes = new HashSet<>();

--- a/src/main/java/crawlercommons/fetcher/http/UserAgent.java
+++ b/src/main/java/crawlercommons/fetcher/http/UserAgent.java
@@ -17,22 +17,34 @@
 package crawlercommons.fetcher.http;
 
 import java.io.Serializable;
-import java.util.Locale;
 
 import crawlercommons.util.HttpFetcherVersion;
 
 /**
  * User Agent enables us to describe characteristics of any http-fetcher
- * agent. There are a number of constructor options to describe the following:
+ * agent. There are a number of configurable options to describe the following:
  * <ol>
- * <li><code>_agentName</code>: Primary agent name.</li>
- * <li><code>_emailAddress</code>: The agent owners email address.</li>
- * <li><code>_webAddress</code>: A web site/address representing the agent owner.</li>
- * <li><code>_browserVersion</code>: Broswer version used for compatibility.</li>
- * <li><code>_crawlerVersion</code>: Version of the user agents personal crawler. If
+ * <li><code>agentName</code>: Primary agent name.</li>
+ * <li><code>emailAddress</code>: The agent owners email address.</li>
+ * <li><code>webAddress</code>: A web site/address representing the agent owner.</li>
+ * <li><code>browserVersion</code>: Browser version used for compatibility.</li>
+ * <li><code>crawlerVersion</code>: Version of the user agents personal crawler. If
  * this is not set, it defaults to the http-fetcher maven artifact version.</li>
+ * <li><code>userAgentString</code>: (Optional) the user-agent string is constructed
+ * automatically if not provided, but can be fully customized via this option.</li>
  * </ol>
- * 
+ * <p>
+ * To construct an UserAgent, you can use a <code>UserAgent.Builder</code> object:
+ * <pre>
+ * {@code
+ *     UserAgent ua = new UserAgent.Builder()
+ *             .setAgentName("MyCrawler")
+ *             .setCrawlerVersion("1.0")
+ *             .setWebAddress("www.mycrawler.com/bot.html")
+ *             .setUserAgentString("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P)")
+ *             .build();
+ * }
+ * </pre>
  */
 @SuppressWarnings("serial")
 public class UserAgent implements Serializable {
@@ -44,17 +56,16 @@ public class UserAgent implements Serializable {
     private final String emailAddress;
     private final String webAddress;
     private final String browserVersion;
+    private final String crawlerVersion;
     private final String crawlerConfiguration;
+    private final String userAgentString;
 
     /**
      * Set user agent characteristics
-     * 
-     * @param agentName
-     *            an agent name string to associate with the crawler
-     * @param emailAddress
-     *            an agent email address string to associate with the crawler
-     * @param webAddress
-     *            a Web address string to associate with the crawler
+     *
+     * @param agentName    an agent name string to associate with the crawler
+     * @param emailAddress an agent email address string to associate with the crawler
+     * @param webAddress   a Web address string to associate with the crawler
      */
     public UserAgent(String agentName, String emailAddress, String webAddress) {
         this(agentName, emailAddress, webAddress, DEFAULT_BROWSER_VERSION);
@@ -62,15 +73,11 @@ public class UserAgent implements Serializable {
 
     /**
      * Set user agent characteristics
-     * 
-     * @param agentName
-     *            an agent name string to associate with the crawler
-     * @param emailAddress
-     *            an agent email address string to associate with the crawler
-     * @param webAddress
-     *            a Web address string to associate with the crawler
-     * @param browserVersion
-     *            a browser version to mimic
+     *
+     * @param agentName      an agent name string to associate with the crawler
+     * @param emailAddress   an agent email address string to associate with the crawler
+     * @param webAddress     a Web address string to associate with the crawler
+     * @param browserVersion a browser version to mimic
      */
     public UserAgent(String agentName, String emailAddress, String webAddress, String browserVersion) {
         this(agentName, emailAddress, webAddress, browserVersion, DEFAULT_CRAWLER_VERSION);
@@ -78,29 +85,44 @@ public class UserAgent implements Serializable {
 
     /**
      * Set user agent characteristics
-     * 
-     * @param agentName
-     *            an agent name string to associate with the crawler
-     * @param emailAddress
-     *            an agent email address string to associate with the crawler
-     * @param webAddress
-     *            a Web address string to associate with the crawler
-     * @param browserVersion
-     *            a browser version to mimic
-     * @param crawlerVersion
-     *            the version of your crawler/crawl agent
+     *
+     * @param agentName      an agent name string to associate with the crawler
+     * @param emailAddress   an agent email address string to associate with the crawler
+     * @param webAddress     a Web address string to associate with the crawler
+     * @param browserVersion a browser version to mimic
+     * @param crawlerVersion the version of your crawler/crawl agent
      */
     public UserAgent(String agentName, String emailAddress, String webAddress, String browserVersion, String crawlerVersion) {
         this.agentName = agentName;
         this.emailAddress = emailAddress;
         this.webAddress = webAddress;
         this.browserVersion = browserVersion;
+        this.crawlerVersion = crawlerVersion;
         this.crawlerConfiguration = crawlerVersion == null ? "" : "/" + crawlerVersion;
+        this.userAgentString = createUserAgentString();
+    }
+
+    public UserAgent(Builder builder) {
+        this.agentName = builder.agentName;
+        this.emailAddress = builder.emailAddress;
+        this.webAddress = builder.webAddress;
+        this.browserVersion = builder.browserVersion;
+        this.crawlerVersion = builder.crawlerVersion;
+        if (builder.crawlerVersion == null) {
+            this.crawlerConfiguration = "";
+        } else {
+            this.crawlerConfiguration = "/" + builder.crawlerVersion;
+        }
+        if (builder.userAgentString == null) {
+            this.userAgentString = createUserAgentString();
+        } else {
+            this.userAgentString = builder.userAgentString;
+        }
     }
 
     /**
-     * Obtain the just the user agent name
-     * 
+     * Obtain just the user agent name
+     *
      * @return User Agent name (String)
      */
     public String getAgentName() {
@@ -109,12 +131,91 @@ public class UserAgent implements Serializable {
 
     /**
      * Obtain a String representing the user agent characteristics.
-     * 
+     *
      * @return User Agent String
      */
     public String getUserAgentString() {
-        // Mozilla/5.0 (compatible; mycrawler/1.0; +http://www.mydomain.com;
-        // mycrawler@mydomain.com)
-        return String.format(Locale.getDefault(), "%s (compatible; %s%s; +%s; %s)", browserVersion, getAgentName(), crawlerConfiguration, webAddress, emailAddress);
+        return userAgentString;
+    }
+
+    /**
+     * Creates a string representing the user agent characteristics. The format is as follows:
+     * "Mozilla/5.0 (compatible; mycrawler/1.0; +http://www.mydomain.com; mycrawler@mydomain.com)"
+     *
+     * @return the User-Agent string
+     */
+    private String createUserAgentString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(browserVersion);
+        sb.append(" (compatible; ");
+        sb.append(agentName);
+        sb.append(crawlerConfiguration);
+        final boolean webAddressIsSet = webAddress != null && !webAddress.isEmpty();
+        final boolean emailAddressIsSet = emailAddress != null && !emailAddress.isEmpty();
+        if (webAddressIsSet || emailAddressIsSet) {
+            sb.append("; ");
+        }
+        if (webAddressIsSet) {
+            sb.append("+");
+            sb.append(webAddress);
+        }
+        if (emailAddressIsSet) {
+            if (webAddressIsSet) {
+                sb.append("; ");
+            }
+            sb.append(emailAddress);
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    /**
+     * Builds a user agent with custom characteristics
+     */
+    public static class Builder {
+
+        private String agentName;
+        private String emailAddress;
+        private String webAddress;
+        private String browserVersion = DEFAULT_BROWSER_VERSION;
+        private String crawlerVersion = DEFAULT_CRAWLER_VERSION;
+        private String userAgentString;
+
+        public Builder() {
+        }
+
+        public Builder setAgentName(String agentName) {
+            this.agentName = agentName;
+            return this;
+        }
+
+        public Builder setEmailAddress(String emailAddress) {
+            this.emailAddress = emailAddress;
+            return this;
+        }
+
+        public Builder setWebAddress(String webAddress) {
+            this.webAddress = webAddress;
+            return this;
+        }
+
+        public Builder setBrowserVersion(String browserVersion) {
+            this.browserVersion = browserVersion;
+            return this;
+        }
+
+        public Builder setCrawlerVersion(String crawlerVersion) {
+            this.crawlerVersion = crawlerVersion;
+            return this;
+        }
+
+        public Builder setUserAgentString(String userAgentString) {
+            this.userAgentString = userAgentString;
+            return this;
+        }
+
+        public UserAgent build() {
+            return new UserAgent(this);
+        }
     }
 }

--- a/src/test/java/crawlercommons/fetcher/http/UserAgentTest.java
+++ b/src/test/java/crawlercommons/fetcher/http/UserAgentTest.java
@@ -1,9 +1,10 @@
 package crawlercommons.fetcher.http;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 
 public class UserAgentTest {
     String agentName = "mycrawler";
@@ -25,9 +26,79 @@ public class UserAgentTest {
     public void testUserAgentDefaultConstructor() {
         UserAgent ua = new UserAgent(agentName, mail, webAddress);
         assertEquals(
-                String.format("%s (compatible; mycrawler/%s; +http://www.mydomain.com; mycrawler@mydomain.com)",
+                String.format(Locale.getDefault(),
+                        "%s (compatible; mycrawler/%s; +http://www.mydomain.com; mycrawler@mydomain.com)",
                         UserAgent.DEFAULT_BROWSER_VERSION, UserAgent.DEFAULT_CRAWLER_VERSION),
                 ua.getUserAgentString());
         assertEquals(agentName, ua.getAgentName());
+    }
+
+    @Test
+    public void buildUserAgentString1() {
+        UserAgent ua = new UserAgent.Builder()
+            .setAgentName("MyCrawler")
+            .setCrawlerVersion("1.0")
+            .build();
+        assertEquals("Mozilla/5.0 (compatible; MyCrawler/1.0)", ua.getUserAgentString());
+        assertEquals("MyCrawler", ua.getAgentName());
+    }
+
+    @Test
+    public void buildUserAgentString2() {
+        UserAgent ua = new UserAgent.Builder()
+            .setAgentName("MyCrawler")
+            .setCrawlerVersion("1.0")
+            .setWebAddress("www.mycrawler.com/bot.html")
+            .build();
+        assertEquals("Mozilla/5.0 (compatible; MyCrawler/1.0; +www.mycrawler.com/bot.html)", ua.getUserAgentString());
+        assertEquals("MyCrawler", ua.getAgentName());
+    }
+
+    @Test
+    public void buildUserAgentString3() {
+        UserAgent ua = new UserAgent.Builder()
+            .setAgentName("MyCrawler")
+            .setCrawlerVersion("1.0")
+            .setEmailAddress("bot@mycrawler.com")
+            .build();
+        assertEquals("Mozilla/5.0 (compatible; MyCrawler/1.0; bot@mycrawler.com)", ua.getUserAgentString());
+        assertEquals("MyCrawler", ua.getAgentName());
+    }
+
+    @Test
+    public void buildUserAgentString4() {
+        UserAgent ua = new UserAgent.Builder()
+            .setAgentName("MyCrawler")
+            .setCrawlerVersion("1.0")
+            .setWebAddress("www.mycrawler.com/bot.html")
+            .setEmailAddress("bot@mycrawler.com")
+            .build();
+        assertEquals("Mozilla/5.0 (compatible; MyCrawler/1.0; +www.mycrawler.com/bot.html; bot@mycrawler.com)", ua.getUserAgentString());
+        assertEquals("MyCrawler", ua.getAgentName());
+    }
+
+    @Test
+    public void buildUserAgentString5() {
+        UserAgent ua = new UserAgent.Builder()
+            .setAgentName("MyCrawler")
+            .setCrawlerVersion("1.0")
+            .setWebAddress("www.mycrawler.com/bot.html")
+            .setUserAgentString("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P)")
+            .build();
+        assertEquals("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P)", ua.getUserAgentString());
+        assertEquals("MyCrawler", ua.getAgentName());
+    }
+
+    @Test
+    public void buildUserAgentString6() {
+        UserAgent ua = new UserAgent.Builder()
+                .setAgentName("MyCrawler")
+                .setCrawlerVersion("1.0")
+                .setBrowserVersion("Mozilla/6.0")
+                .setWebAddress("www.mycrawler.com/bot.html")
+                .setEmailAddress("bot@mycrawler.com")
+                .build();
+        assertEquals("Mozilla/6.0 (compatible; MyCrawler/1.0; +www.mycrawler.com/bot.html; bot@mycrawler.com)", ua.getUserAgentString());
+        assertEquals("MyCrawler", ua.getAgentName());
     }
 }

--- a/src/test/java/crawlercommons/fetcher/http/UserAgentTest.java
+++ b/src/test/java/crawlercommons/fetcher/http/UserAgentTest.java
@@ -1,0 +1,33 @@
+package crawlercommons.fetcher.http;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+
+public class UserAgentTest {
+    String agentName = "mycrawler";
+    String mail = "mycrawler@mydomain.com";
+    String webAddress = "http://www.mydomain.com";
+    String browserVersion = "Mozilla/5.0";
+    String crawlerVersion = "0.1";
+
+    @Test
+    public void testUserAgentFullConstructor() {
+        UserAgent ua = new UserAgent(agentName, mail, webAddress, browserVersion, crawlerVersion);
+        assertEquals(
+                "Mozilla/5.0 (compatible; mycrawler/0.1; +http://www.mydomain.com; mycrawler@mydomain.com)",
+                ua.getUserAgentString());
+        assertEquals(agentName, ua.getAgentName());
+    }
+
+    @Test
+    public void testUserAgentDefaultConstructor() {
+        UserAgent ua = new UserAgent(agentName, mail, webAddress);
+        assertEquals(
+                String.format("%s (compatible; mycrawler/%s; +http://www.mydomain.com; mycrawler@mydomain.com)",
+                        UserAgent.DEFAULT_BROWSER_VERSION, UserAgent.DEFAULT_CRAWLER_VERSION),
+                ua.getUserAgentString());
+        assertEquals(agentName, ua.getAgentName());
+    }
+}


### PR DESCRIPTION
This PR allows a more flexible configuration of the User-Agent string using the builder pattern. It also adds unit tests to ensure compatibility with previous implementations that used only class constructors. In the future, we could deprecate the constructors if others agree.